### PR TITLE
Ignore netbeans generated-sources when analyzing a project node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.sonarsource.sonarlint.core</groupId>
             <artifactId>sonarlint-core</artifactId>
-            <version>5.2.0.28259</version>
+            <version>6.1.0.33448</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/github/philippefichet/sonarlint4netbeans/SonarLintUtils.java
+++ b/src/main/java/com/github/philippefichet/sonarlint4netbeans/SonarLintUtils.java
@@ -306,7 +306,7 @@ public final class SonarLintUtils {
                     Files.walkFileTree(file.toPath(), new FileVisitor<Path>() {
                         @Override
                         public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                            return FileVisitResult.CONTINUE;
+                            return dir.endsWith("generated-sources") ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
                         }
                         
                         @Override

--- a/src/main/java/com/github/philippefichet/sonarlint4netbeans/SonarLintUtils.java
+++ b/src/main/java/com/github/philippefichet/sonarlint4netbeans/SonarLintUtils.java
@@ -256,13 +256,18 @@ public final class SonarLintUtils {
             // Map file to implementation of ClientInputFile
             Path path = file.toPath();
             try {
-                Charset encoding = FileEncodingQuery.getEncoding(FileUtil.toFileObject(file));
                 FileObject fileObject = FileUtil.toFileObject(file);
+                // ignore null FileObject (e.g. .nbattr) as getEncoding throws IllegalArgumentException
+                if (fileObject == null)
+                {
+                    continue;
+                }
+                Charset encoding = FileEncodingQuery.getEncoding(fileObject);
                 clientInputFiles.add(new FSClientInputFile(
                     new String(Files.readAllBytes(path)),
                     path.toAbsolutePath(),
                     path.toFile().getName(),
-                    fileObject != null && SonarLintUtils.isTest(fileObject),
+                    SonarLintUtils.isTest(fileObject),
                     encoding
                 ));
             } catch (IOException ex) {

--- a/src/test/java/com/github/philippefichet/sonarlint4netbeans/SonarLintUtilsTest.java
+++ b/src/test/java/com/github/philippefichet/sonarlint4netbeans/SonarLintUtilsTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.openide.filesystems.FileUtil;
 import org.openide.nodes.Node;
 import org.openide.util.Lookup;
+import org.openide.util.Utilities;
 import org.sonarsource.sonarlint.core.client.api.common.RuleKey;
 import org.sonarsource.sonarlint.core.client.api.common.Version;
 import org.sonarsource.sonarlint.core.client.api.common.analysis.Issue;
@@ -393,7 +394,7 @@ public class SonarLintUtilsTest {
     {
         SonarLintTestUtils.installNodeJS();
         File nodeJSDirectory = SonarLintTestUtils.getNodeJSDirectory();
-        String node = SonarLintTestUtils.isWindowsOS() ? "node.exe" : "bin/node";
+        String node = Utilities.isWindows() ? "node.exe" : "bin/node";
         Optional<Version> detectNodeJSVersion = SonarLintUtils.detectNodeJSVersion(nodeJSDirectory.getAbsolutePath() + File.separator + node);
         Assertions.assertThat(detectNodeJSVersion).isPresent().get().isEqualTo(Version.create(SonarLintTestUtils.getNodeJSVersion()));
     }


### PR DESCRIPTION
This PR: 

- adds support to run Node.js tests on macOS
- ignores netbeans generated-sources (e.g. Bundle annotation sources)
- updates sonarlin-core to latest version 6.1.0.33448
- avoids IllegalArgumentException when querying file encoding and FileObject is null.